### PR TITLE
Support rotation of a vector

### DIFF
--- a/lib/vector2d/transformations.rb
+++ b/lib/vector2d/transformations.rb
@@ -52,12 +52,21 @@ class Vector2d
       self.class.new(-x, -y)
     end
 
+    # Rotates the vector
+    #
+    #   Vector2d(1, 0).rotate(Math:PI/2) => Vector2d(1,0)
+    #
+    def rotate(angle)
+      Vector2d.new(x * Math.cos(angle) - y * Math.sin(angle), x * Math.sin(angle) + y * Math.cos(angle))
+    end
+
     # Rounds vector to nearest integer.
     #
     #   Vector2d(2.4, 3.6).round # => Vector2d(2,4)
+    #   Vector2d(2.4444, 3.666).round(2) # => Vector2d(2.44, 3.67)
     #
-    def round
-      self.class.new(x.round, y.round)
+    def round(digits=0)
+      self.class.new(x.round(digits), y.round(digits))
     end
 
     # Truncates to max length if vector is longer than max.

--- a/spec/lib/vector2d/transformations_spec.rb
+++ b/spec/lib/vector2d/transformations_spec.rb
@@ -47,10 +47,21 @@ describe Vector2d::Transformations do
     end
   end
 
+  describe "#rotate" do
+    let(:vector) { Vector2d.new(1, 0) }
+    it "rotates the vector" do
+      expect(vector.rotate(Math::PI).round(1)).to eq(Vector2d.new(-1, 0))
+      expect(vector.rotate(Math::PI/2).round(1)).to eq(Vector2d.new(0, 1))
+      expect(vector.rotate(-Math::PI/2).round(1)).to eq(Vector2d.new(0, -1))
+      expect(vector.rotate(Math::PI/4).round(3)).to eq(Vector2d.new(0.707, 0.707))
+    end
+  end
+
   describe "#round" do
-    subject(:vector) { Vector2d.new(2.3, 3.6) }
+    subject(:vector) { Vector2d.new(2.3333, 3.666) }
     it "rounds the vector" do
       expect(vector.round).to eq(Vector2d.new(2, 4))
+      expect(vector.round(2)).to eq (Vector2d.new(2.33, 3.67))
     end
   end
 
@@ -68,4 +79,6 @@ describe Vector2d::Transformations do
       end
     end
   end
+
+
 end


### PR DESCRIPTION
Hi, I need to rotate a vector by a given angle.
When I wrote the tests, I needed round to be like Float.round as of Ruby 1.9

Now support round as in ruby 1.9.3 -> round(digits = 0)
